### PR TITLE
Improve readme: GL_GITCONFIG_KEYS is a regexp

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,16 @@ be tedious to use if you are just looking to mirror push some repositories to
 Github (*).
 
 Here is an alternative *post-receive* hook that doesn't bother with
-master/slave declarations, and just lets you define a target repository
+master/slave declarations, and just lets you define one or more target repositories
 to which to mirror like so:
 
     repo    foo-project
             RW+     =   me
             config gitolite.mirror.simple   =   "git@github.com:miracle2k/foo-project.git"
+            
+    repo    bar-project
+            RW+     =   me
+            config gitolite.mirror.simple   =   "git@github.com:miracle2k/bar-project.git git@bitbucket.org:miracle2k/bar-project.git"
             
 It's also possible to mirror multiple repositories in one go:
 

--- a/post-receive
+++ b/post-receive
@@ -8,13 +8,14 @@
 
 [ -z "$GL_REPO" ] && die GL_REPO not set
 
-target=`git config --get gitolite.mirror.simple`
-[ -z "$target" ] && exit 0
+targets=`git config --get gitolite.mirror.simple`
+[ -z "$targets" ] && exit 0
 
-# Support a REPO variable for wildcard mirrors
-gl_repo_escaped=$(echo $GL_REPO | sed 's/\//\\\//g')
-target=$(echo $target | sed -e "s/REPO/$gl_repo_escaped/g")
+for target in $targets; do
+	# Support a REPO variable for wildcard mirrors
+	gl_repo_escaped=$(echo $GL_REPO | sed 's/\//\\\//g')
+	target=$(echo $target | sed -e "s/REPO/$gl_repo_escaped/g")
 
-# Do the mirror push
-git push --mirror $target
-
+	# Do the mirror push
+	git push --mirror $target
+done


### PR DESCRIPTION
The one in the docs would allow things like:

gitoliteimirrorpoohbaah!
